### PR TITLE
Removing strange characters which made the jeckyll sass compiler crash

### DIFF
--- a/src/elements/_elements__document.scss
+++ b/src/elements/_elements__document.scss
@@ -10,7 +10,7 @@
  * 1. Set the default `font-size` and `line-height` for the entire project,
  *    sourced from our default variables. The `font-size` is calculated to exist
  *    in ems, the `line-height` is calculated to exist unitlessly.
- * 2. Force scrollbars to always be visible to prevent awkward ‘jumps’ when
+ * 2. Force scrollbars to always be visible to prevent awkward `jumps` when
  *    navigating between pages that do/do not have enough content to produce
  *    scrollbars naturally.
  * 3. Ensure the page always fills at least the entire height of the viewport.

--- a/src/tools/_tools__sass-mq.scss
+++ b/src/tools/_tools__sass-mq.scss
@@ -119,7 +119,7 @@ $t-sass-mq__debug--border-color:    $f-color__neutral-grey--light !default;
     // Loop through the breakpoints that should be shown
     @each $_bp-name, $_bp-value in $_breakpoints {
       @include t-mq($from: $_bp-name) {
-        content: "#{$_bp-name} ≥ #{$_bp-value}";
+        content: "#{$_bp-name} >= #{$_bp-value}";
       }
     }
   }

--- a/src/tools/vendor/_quantity-queries.scss
+++ b/src/tools/vendor/_quantity-queries.scss
@@ -160,7 +160,7 @@
   }
 
   @if $first > $last {
-    @error '#{$first} can´t be larger that #{$last} for `between`';
+    @error '#{$first} can\'t be larger that #{$last} for `between`';
   }
 
   @if $selector != null and (type-of($selector) != 'string' or length($selector) > 1) {

--- a/src/utilities/_utilities__widths.scss
+++ b/src/utilities/_utilities__widths.scss
@@ -3,7 +3,7 @@
  * WIDTHS
  *
  * Generates a series of utility classes that give a fluid width to
- * whichever element they’re applied, combining the fractions numbers, e.g.:
+ * whichever element they're applied, combining the fractions numbers, e.g.:
  *
  *   <img src="" alt="" class="u-1/2" />
  *


### PR DESCRIPTION
In some Jeckyll setups the compiler is crashing sue to some special characters, I've replaced them.