### PR TITLE
Fixing o-pack object 

### DIFF
--- a/src/objects/_objects__pack.scss
+++ b/src/objects/_objects__pack.scss
@@ -49,6 +49,7 @@ $o-pack__mod-auto--enabled:                 true !default;
   margin-left: 0;
   display: table;
   table-layout: fixed;
+  border-collapse: separate;
   border-spacing: s-core-px-to-rem($_space-value);
 }
 
@@ -152,6 +153,7 @@ $o-pack__mod-auto--enabled:                 true !default;
   margin-left: inherit;
   display: inherit;
   table-layout: inherit;
+  border-collapse: inherit;
   border-spacing: inherit;
 }
 


### PR DESCRIPTION
In the situation of the parent having the "border-collapse" property setted to "collapse", in that case the spacing of the object were not correctly applyed cause the spacing is
set via border-spacing (such as the elements is build with display-table). For
more information about this property check:

https://developer.mozilla.org/en-US/docs/Web/CSS/border-collapse