### PR TITLE
Fixing o-list-inline issues

### DIFF
--- a/src/objects/_objects__list-inline.scss
+++ b/src/objects/_objects__list-inline.scss
@@ -22,6 +22,7 @@ $o-list-inline--enabled:                      true !default;
   > * {
     font-size: s-core-px-to-rem($s-core__font-size);
     display: inline-block;
+    width: auto;
   }
 }
 
@@ -44,5 +45,6 @@ $o-list-inline--enabled:                      true !default;
   > * {
     font-size: inherit;
     display: inherit;
+    width: inherit;
   }
 }


### PR DESCRIPTION
Forcing o-list-inline items to have `width: auto;` to avoid to have items with `width: 100%;` in which case they won't be inlined at all.

Related issue: https://github.com/haiticss/haiticss/issues/80